### PR TITLE
Add support for BDBag metadata and RO-metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This will give you a client you can use to access the Concierge Service
 
     cbag --help
 
+## Basic Usage
+
 Creating a bag is fast and easy, point the client at a
 [Remote File Manifest](https://github.com/fair-research/bdbag/blob/master/doc/config.md#remote-file-manifest)
 and it will create it along with a minid.
@@ -22,3 +24,12 @@ and it will create it along with a minid.
 The result is a valid minid identifier that can be queried with the minid client:
 
     minid ark:/99999/fk4hq54x0r
+
+You can optionally supply metadata for bag creation:
+
+    cbag create remote-files.json "My Bag with Metadata" -m metadata.json
+
+See the BDBag docs for more info about the structure of `remote-files.json`
+and `metadata.json`. For more info on `cbag create` you can run the following:
+
+    cbag create --help

--- a/concierge/api.py
+++ b/concierge/api.py
@@ -28,7 +28,8 @@ def _concierge_response(response):
         raise ConciergeException(**rjson)
 
 
-def create_bag(server, remote_file_manifest, name, email, title, bearer_token):
+def create_bag(server, remote_file_manifest, name, email, title, bearer_token,
+               metadata={}):
     """
     :param remote_file_manifest: The BDBag remote file manifest for the bag.
     Docs can be found here:
@@ -38,13 +39,16 @@ def create_bag(server, remote_file_manifest, name, email, title, bearer_token):
                     globus-linked-identity)
     :param title: The title of the minid
     :param bearer_token: A User Globus access token
+    :param metadata: Optional metadata for the bdbag. Must be a dict of the
+                     format:
+                     {"bag_metadata": {...}, "ro_metadata": {...} }
     :return: Creates a BDBag from the manifest, registers it and returns
      the resulting Minid
     """
     headers = {'Authorization': 'Bearer {}'.format(bearer_token)}
     data = {
       'minid_user': name, 'minid_email': email, 'minid_title': title,
-      'remote_files_manifest': remote_file_manifest
+      'remote_files_manifest': remote_file_manifest, 'metadata': metadata
     }
     url = '{}/api/bags/'.format(server)
     response = requests.post(url, headers=headers, json=data)

--- a/concierge/api.py
+++ b/concierge/api.py
@@ -29,7 +29,7 @@ def _concierge_response(response):
 
 
 def create_bag(server, remote_file_manifest, name, email, title, bearer_token,
-               metadata={}):
+               metadata={}, ro_metadata={}):
     """
     :param remote_file_manifest: The BDBag remote file manifest for the bag.
     Docs can be found here:
@@ -42,13 +42,17 @@ def create_bag(server, remote_file_manifest, name, email, title, bearer_token,
     :param metadata: Optional metadata for the bdbag. Must be a dict of the
                      format:
                      {"bag_metadata": {...}, "ro_metadata": {...} }
+    :param ro_metadata: Research Object metadata, see BDBag docs for more info
+                        on usage and file syntax:
+                        https://github.com/fair-research/bdbag/tree/ro-metadata-enhancements/examples/metamanifests  # noqa
     :return: Creates a BDBag from the manifest, registers it and returns
      the resulting Minid
     """
     headers = {'Authorization': 'Bearer {}'.format(bearer_token)}
     data = {
       'minid_user': name, 'minid_email': email, 'minid_title': title,
-      'remote_files_manifest': remote_file_manifest, 'metadata': metadata
+      'remote_files_manifest': remote_file_manifest, 'metadata': metadata,
+      'ro_metadata': ro_metadata
     }
     url = '{}/api/bags/'.format(server)
     response = requests.post(url, headers=headers, json=data)

--- a/concierge/client.py
+++ b/concierge/client.py
@@ -2,6 +2,7 @@ import os
 import sys
 import click
 import json
+import requests
 from concierge.globus_login import login as glogin
 from concierge.globus_login import get_info
 from concierge.api import create_bag
@@ -42,13 +43,17 @@ def create(remote_file_manifest, title, server, metadata, ro_metadata):
             bag_metadata = json.loads(metadata.read())
         if ro_metadata:
             ro_bag_metadata = json.loads(ro_metadata.read())
+        if any([isinstance(v, dict) for v in bag_metadata.values()]):
+            click.echo('Warning: Metadata contains complex objects.', err=True)
         bag = create_bag(server, rfm_file, info['name'],
                          info['email'], title, access_token,
                          metadata=bag_metadata,
                          ro_metadata=ro_bag_metadata)
         click.echo('{}'.format(bag['minid_id']))
     except ConciergeException as ce:
-        click.echo('Error Creating Bag: {}'.format(ce.message))
+        click.echo('Error Creating Bag: {}'.format(ce.message), err=True)
+    except requests.exceptions.ConnectionError as ce:
+        click.echo(str(ce), err=True)
 
 
 def update(path, minid):

--- a/concierge/client.py
+++ b/concierge/client.py
@@ -25,23 +25,27 @@ def globus():
 
 
 @main.command(help='Create a BDBag with a Remote File Manifest')
+@click.option('--ro-metadata', type=click.File('r'), nargs=1)
 @click.option('--metadata', '-m', type=click.File('r'), nargs=1)
 @click.option('--server', '-s', help='Concierge server to use',
               default='https://concierge.fair-research.org')
 @click.argument('remote_file_manifest', type=click.File('r'))
 @click.argument('title')
-def create(remote_file_manifest, title, server, metadata):
+def create(remote_file_manifest, title, server, metadata, ro_metadata):
     try:
         # this should take an optional metadata
         info = get_info()
         access_token = info['tokens']['auth.globus.org']['access_token']
         rfm_file = json.loads(remote_file_manifest.read())
-        bag_metadata = {}
+        bag_metadata, ro_bag_metadata = {}, {}
         if metadata:
             bag_metadata = json.loads(metadata.read())
+        if ro_metadata:
+            ro_bag_metadata = json.loads(ro_metadata.read())
         bag = create_bag(server, rfm_file, info['name'],
                          info['email'], title, access_token,
-                         metadata=bag_metadata)
+                         metadata=bag_metadata,
+                         ro_metadata=ro_bag_metadata)
         click.echo('{}'.format(bag['minid_id']))
     except ConciergeException as ce:
         click.echo('Error Creating Bag: {}'.format(ce.message))

--- a/concierge/client.py
+++ b/concierge/client.py
@@ -25,26 +25,26 @@ def globus():
 
 
 @main.command(help='Create a BDBag with a Remote File Manifest')
+@click.option('--metadata', '-m', type=click.File('r'), nargs=1)
 @click.option('--server', '-s', help='Concierge server to use',
               default='https://concierge.fair-research.org')
-@click.argument('remote_file_manifest')
+@click.argument('remote_file_manifest', type=click.File('r'))
 @click.argument('title')
-def create(remote_file_manifest, title, server):
-    if not os.path.exists(remote_file_manifest):
-        click.echo('Remote File Manifest "{}" '
-                   'does not exist'.format(remote_file_manifest))
-        sys.exit(2)
-    with open(remote_file_manifest) as f:
-        try:
-            # this should take an optional metadata
-            info = get_info()
-            access_token = info['tokens']['auth.globus.org']['access_token']
-            rfm_file = json.loads(f.read())
-            bag = create_bag(server, rfm_file, info['name'],
-                             info['email'], title, access_token)
-            click.echo('{}'.format(bag['minid_id']))
-        except ConciergeException as ce:
-            click.echo('Error Creating Bag: {}'.format(ce.message))
+def create(remote_file_manifest, title, server, metadata):
+    try:
+        # this should take an optional metadata
+        info = get_info()
+        access_token = info['tokens']['auth.globus.org']['access_token']
+        rfm_file = json.loads(remote_file_manifest.read())
+        bag_metadata = {}
+        if metadata:
+            bag_metadata = json.loads(metadata.read())
+        bag = create_bag(server, rfm_file, info['name'],
+                         info['email'], title, access_token,
+                         metadata=bag_metadata)
+        click.echo('{}'.format(bag['minid_id']))
+    except ConciergeException as ce:
+        click.echo('Error Creating Bag: {}'.format(ce.message))
 
 
 def update(path, minid):


### PR DESCRIPTION
This adds support for creating both regular metadata, and ro_metadata for BDBags. It's based on current new [functionality in development here](https://github.com/fair-research/bdbag/tree/ro-metadata-enhancements).

Relies on https://github.com/fair-research/concierge/issues/3.